### PR TITLE
Correção no manifest sobre FacebookActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -63,8 +63,7 @@
         <activity
             android:name="com.facebook.FacebookActivity"
             android:configChanges="keyboard|keyboardHidden|screenLayout|screenSize|orientation"
-            android:label="@string/app_name"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            android:label="@string/app_name"/>
 
     </application>
 


### PR DESCRIPTION
Ao rodar o build, o Android Studio acusou um problema no manifest indicando ao que entendi ser um conflito entre o style declarado em FacebookActivity no manifest do Plantare e o style no manifest do próprio Facebook. Removi esse style do Plantare para que seja utilizado o do Facebook.

Segue o log:

Error:Execution failed for task ':app:processDebugManifest'.

> Manifest merger failed : Attribute activity#com.facebook.FacebookActivity@theme value=(@android:style/Theme.Translucent.NoTitleBar) from AndroidManifest.xml:67:13-72
>     is also present at [com.facebook.android:facebook-android-sdk:4.16.0] AndroidManifest.xml:32:13-63 value=(@style/com_facebook_activity_theme).
>     Suggestion: add 'tools:replace="android:theme"' to <activity> element at AndroidManifest.xml:63:9-67:75 to override.

@firemanxbr @DanielNogueiraAndroid @jbalves @gleidesigner @Wandersonjack @geiciane @John-Ke 
